### PR TITLE
Implement backend password update and improve Angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# MediApp1
+
+## Requisitos
+- Node.js 18+
+- NPM
+- MySQL
+
+## Instalación
+
+### Backend
+1. `cd backend-mediapp`
+2. `npm install`
+3. Copiar `.env.example` a `.env` y configurar variables de base de datos y `JWT_SECRET`.
+4. `node app.js` o `npx nodemon app.js`
+
+### Frontend
+1. En la raíz del proyecto: `npm install`
+2. `ionic serve` para desarrollo
+
+## Uso
+- La API quedará disponible en `http://localhost:3000/api` por defecto.
+- La aplicación Ionic usa dicha URL configurada en los archivos de entorno.

--- a/backend-mediapp/controllers/auth.controller.js
+++ b/backend-mediapp/controllers/auth.controller.js
@@ -5,9 +5,6 @@ require('dotenv').config();
 
 exports.login = async (req, res) => {
   const { numero_usuario, password } = req.body;
-  console.log('🔐 LOGIN DEBUG');
-  console.log('Usuario recibido:', numero_usuario);
-  console.log('Contraseña recibida:', password);
 
   try {
     // 1. Busca el usuario
@@ -21,12 +18,10 @@ exports.login = async (req, res) => {
       return res.status(404).json({ mensaje: 'Usuario no encontrado' });
     }
 
-    const usuario = rows[0];
-    console.log('Hash en BD:', usuario.password);
+      const usuario = rows[0];
 
     // 2. Compara contraseñas
     const passwordValida = await bcrypt.compare(password, usuario.password);
-    console.log('bcrypt.compare result:', passwordValida);
 
     if (!passwordValida) {
       console.log('❌ La contraseña NO coincide');
@@ -50,5 +45,26 @@ exports.login = async (req, res) => {
   } catch (error) {
     console.error('⚠️ Error en login:', error);
     res.status(500).json({ mensaje: 'Error al iniciar sesión' });
+  }
+};
+
+exports.cambiarPassword = async (req, res) => {
+  const { nuevaPassword } = req.body;
+  const usuarioId = req.usuario?.id;
+
+  if (!nuevaPassword || !usuarioId) {
+    return res.status(400).json({ mensaje: 'Datos incompletos' });
+  }
+
+  try {
+    const hash = await bcrypt.hash(nuevaPassword, 10);
+    await pool.query(
+      'UPDATE usuarios SET password = ?, requiere_cambio_password = false WHERE id = ?',
+      [hash, usuarioId]
+    );
+    res.json({ mensaje: 'Contraseña actualizada correctamente' });
+  } catch (error) {
+    console.error('❌ Error al cambiar contraseña:', error);
+    res.status(500).json({ mensaje: 'Error al cambiar contraseña' });
   }
 };

--- a/backend-mediapp/controllers/registro.controller.js
+++ b/backend-mediapp/controllers/registro.controller.js
@@ -44,7 +44,13 @@ exports.obtenerRegistros = async (req, res) => {
     }
 
     console.log('🔢 Registros encontrados:', registros.length);
-    res.json(registros);
+    const parsed = registros.map(reg => ({
+      ...reg,
+      datos_json: (() => {
+        try { return JSON.parse(reg.datos_json); } catch { return reg.datos_json; }
+      })()
+    }));
+    res.json(parsed);
   } catch (error) {
     console.error('❌ Error al obtener registros:', error);
     res.status(500).json({ mensaje: 'Error al obtener registros' });

--- a/backend-mediapp/controllers/usuario.controller.js
+++ b/backend-mediapp/controllers/usuario.controller.js
@@ -18,3 +18,15 @@ exports.crearUsuario = async (req, res) => {
     res.status(500).json({ mensaje: 'Error al crear usuario', error });
   }
 };
+
+exports.listarUsuarios = async (req, res) => {
+  try {
+    const [rows] = await pool.query(
+      'SELECT id, nombre, area, puesto, numero_usuario, rol FROM usuarios'
+    );
+    res.json(rows);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ mensaje: 'Error al obtener usuarios', error });
+  }
+};

--- a/backend-mediapp/routes/usuario.routes.js
+++ b/backend-mediapp/routes/usuario.routes.js
@@ -5,4 +5,6 @@ const usuarioCtrl = require('../controllers/usuario.controller');
 // Registro abierto, sin requerir token
 router.post('/crear', usuarioCtrl.crearUsuario);
 
+router.get('/listar', usuarioCtrl.listarUsuarios);
+
 module.exports = router;

--- a/src/app/pages/login/login.page.ts
+++ b/src/app/pages/login/login.page.ts
@@ -19,29 +19,29 @@ export class LoginPage {
 
   constructor(private api: ApiService, private router: Router) {}
 
-  async iniciarSesion() {
+  iniciarSesion() {
     this.mensaje = '';
 
-    try {
-      const res: any = await this.api.login(this.numero_usuario, this.password).toPromise();
-
-      this.api.setToken(res.token);
-      const usuario = res.usuario;
+    this.api.login(this.numero_usuario, this.password).subscribe({
+      next: (res: any) => {
+        this.api.setToken(res.token);
+        const usuario = res.usuario;
 
       console.log('🧪 DEBUG => requiere_cambio_password:', usuario.requiere_cambio_password, '| tipo:', typeof usuario.requiere_cambio_password);
 
       // Evaluar tanto boolean como número (por si viene como 1)
-      if (usuario.requiere_cambio_password === true || usuario.requiere_cambio_password === 1) {
-        console.log('➡️ Redirigiendo a /cambiar-password');
-        this.router.navigate(['/cambiar-password']);
-      } else {
-        console.log('➡️ Redirigiendo a /home');
-        this.router.navigate(['/home']);
+        if (usuario.requiere_cambio_password === true || usuario.requiere_cambio_password === 1) {
+          console.log('➡️ Redirigiendo a /cambiar-password');
+          this.router.navigate(['/cambiar-password']);
+        } else {
+          console.log('➡️ Redirigiendo a /home');
+          this.router.navigate(['/home']);
+        }
+      },
+      error: () => {
+        console.error('❌ Error en login');
+        this.mensaje = 'Credenciales incorrectas';
       }
-
-    } catch (error: any) {
-      console.error('❌ Error en login:', error);
-      this.mensaje = 'Credenciales incorrectas';
-    }
+    });
   }
 }

--- a/src/app/pages/primer-cambio-password/primer-cambio-password.page.ts
+++ b/src/app/pages/primer-cambio-password/primer-cambio-password.page.ts
@@ -19,7 +19,7 @@ export class PrimerCambioPasswordPage {
 
   constructor(private api: ApiService, private router: Router) {}
 
-  async cambiar() {
+  cambiar() {
     this.mensaje = '';
 
     if (this.nuevaPassword !== this.confirmarPassword) {
@@ -27,12 +27,14 @@ export class PrimerCambioPasswordPage {
       return;
     }
 
-    try {
-      await this.api.cambiarPassword(this.nuevaPassword).toPromise();
-      alert('Contraseña actualizada correctamente');
-      this.router.navigate(['/home']);
-    } catch (error) {
-      this.mensaje = 'Error al cambiar la contraseña';
-    }
+    this.api.cambiarPassword(this.nuevaPassword).subscribe({
+      next: () => {
+        alert('Contraseña actualizada correctamente');
+        this.router.navigate(['/home']);
+      },
+      error: () => {
+        this.mensaje = 'Error al cambiar la contraseña';
+      }
+    });
   }
 }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,8 +1,9 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
-const API_URL = 'http://localhost:3000/api';
+const API_URL = environment.apiUrl;
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -4,6 +4,19 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class StorageService {
+  setItem(key: string, value: string): void {
+    localStorage.setItem(key, value);
+  }
 
-  constructor() { }
+  getItem(key: string): string | null {
+    return localStorage.getItem(key);
+  }
+
+  removeItem(key: string): void {
+    localStorage.removeItem(key);
+  }
+
+  clear(): void {
+    localStorage.clear();
+  }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  apiUrl: 'http://localhost:3000/api'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiUrl: 'http://localhost:3000/api'
 };
 
 /*


### PR DESCRIPTION
## Summary
- add API url to Angular environments and use it in the ApiService
- refactor login and password change pages to use observables instead of `toPromise`
- implement basic storage service
- implement password change endpoint with bcrypt
- parse JSON data in records controller
- add users list endpoint and route
- create project README

## Testing
- `npm test` *(fails: ng not found)*